### PR TITLE
integrate mimalloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(RF_BUILD_APPS "Build applications in addition to library" ON)
 option(RF_BUILD_BINDINGS "Build python bindings with pybind" OFF)
 option(BUILD_SHARED_LIBS "Build using shared libraries (may not work)" OFF)
 option(RF_BUILD_TESTING "Enable tests for roofer" OFF)
+option(RF_ENABLE_HEAP_TRACING "Enable heap allocation overloads" OFF)
 
 # Enable the vcpkg features that are required by the options
 if(RF_USE_LOGGER_SPDLOG)

--- a/apps/roofer-app/CMakeLists.txt
+++ b/apps/roofer-app/CMakeLists.txt
@@ -1,9 +1,12 @@
 set(APP_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/roofer-app.cpp")
 
+find_package(mimalloc CONFIG REQUIRED)
+
 add_executable("roofer" ${APP_SOURCES})
 set_target_properties("roofer" PROPERTIES CXX_STANDARD 20)
 target_link_libraries("roofer" PRIVATE roofer-extra cmake_git_version_tracking
-                                       fmt::fmt)
+                                       fmt::fmt
+                                       $<IF:$<TARGET_EXISTS:mimalloc-static>,mimalloc-static,mimalloc>)
 
 # Used for getting the process memory usage
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -18,6 +21,9 @@ endif()
 
 if(RF_USE_VAL3DITY)
   target_compile_definitions("roofer" PRIVATE RF_USE_VAL3DITY)
+endif()
+if(RF_ENABLE_HEAP_TRACING)
+  target_compile_definitions("roofer" PRIVATE RF_ENABLE_HEAP_TRACING)
 endif()
 
 install(

--- a/apps/roofer-app/CMakeLists.txt
+++ b/apps/roofer-app/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(APP_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/roofer-app.cpp")
 
-find_package(mimalloc CONFIG REQUIRED)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  find_package(mimalloc CONFIG REQUIRED)
+endif()
 
 add_executable("roofer" ${APP_SOURCES})
 set_target_properties("roofer" PROPERTIES CXX_STANDARD 20)

--- a/apps/roofer-app/roofer-app.cpp
+++ b/apps/roofer-app/roofer-app.cpp
@@ -79,7 +79,12 @@ namespace fs = std::filesystem;
 #include "git.h"
 #include "toml.hpp"
 
+#if defined(IS_LINUX) || defined(IS_MACOS)
+#include <new>
 #include <mimalloc-override.h>
+#else
+#undef RF_ENABLE_HEAP_TRACING
+#endif
 
 using fileExtent = std::pair<std::string, roofer::TBox<double>>;
 
@@ -443,10 +448,10 @@ namespace {
  * https://github.com/microsoft/mimalloc/blob/dev/include/mimalloc-new-delete.h
  * and modified to work with the roofer trace feature for heap memory usage.
  */
-
+#if defined(IS_LINUX) || defined(IS_MACOS)
 #if defined(_MSC_VER) && defined(_Ret_notnull_) && \
     defined(_Post_writable_byte_size_)
-// stay consistent with VCRT definitions
+   // stay consistent with VCRT definitions
 #define mi_decl_new(n) \
   mi_decl_nodiscard mi_decl_restrict _Ret_notnull_ _Post_writable_byte_size_(n)
 #define mi_decl_new_nothrow(n)                                                 \
@@ -563,7 +568,7 @@ void* operator new[](std::size_t n, std::align_val_t al,
   return mi_new_aligned_nothrow(n, static_cast<size_t>(al));
 }
 #endif
-
+#endif
 /*
  * Author:  David Robert Nadeau
  * Site:    http://NadeauSoftware.com/

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,6 +20,11 @@
         "geos",
         "lastools",
         {
+          "name": "mimalloc",
+          "features": [
+          ]
+        },
+        {
           "name": "gdal",
           "features": [
             "recommended-features",


### PR DESCRIPTION
- Opted to use mimalloc instead of jemalloc due to better cmake and vcpkg integration
- added option `RF_ENABLE_HEAP_TRACING` since I noticed there is a performance impact of doing the heap tracing (even when result is not used)