### PR TITLE
Type formatters and config logging

### DIFF
--- a/apps/roofer-app/config.hpp
+++ b/apps/roofer-app/config.hpp
@@ -18,6 +18,7 @@
 
 // Author(s):
 // Ravi Peters
+// Balázs Dukai
 #pragma once
 
 #include <functional>
@@ -140,6 +141,65 @@ struct RooferConfig {
       {"rmse_lod22", "rf_rmse_lod22"},
       {"h_ground", "rf_h_ground"},
   };
+};
+
+template <>
+struct fmt::formatter<roofer::ReconstructionConfig> {
+  static constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename Context>
+  constexpr auto format(roofer::ReconstructionConfig const& cfg,
+                        Context& ctx) const {
+    return format_to(
+        ctx.out(),
+        "ReconstructionConfig(complexity_factor={}, clip_ground={}, lod={}, "
+        "lod13_step_height={}, floor_elevation={}, "
+        "override_with_floor_elevation={}, plane_detect_k={}, "
+        "plane_detect_min_points={}, plane_detect_epsilon={}, "
+        "plane_detect_normal_angle={}, line_detect_epsilon={}, thres_alpha={}, "
+        "thres_reg_line_dist={}, thres_reg_line_ext={})",
+        cfg.complexity_factor, cfg.clip_ground, cfg.lod, cfg.lod13_step_height,
+        cfg.floor_elevation, cfg.override_with_floor_elevation,
+        cfg.plane_detect_k, cfg.plane_detect_min_points,
+        cfg.plane_detect_epsilon, cfg.plane_detect_normal_angle,
+        cfg.line_detect_epsilon, cfg.thres_alpha, cfg.thres_reg_line_dist,
+        cfg.thres_reg_line_ext);
+  }
+};
+
+template <>
+struct fmt::formatter<RooferConfig> {
+  static constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename Context>
+  constexpr auto format(RooferConfig const& cfg, Context& ctx) const {
+    std::string region_of_interest = "novalue";
+    if (cfg.region_of_interest.has_value()) {
+      region_of_interest = cfg.region_of_interest.value().wkt();
+    }
+    return format_to(
+        ctx.out(),
+        "RooferConfig(source_footprints={}, id_attribute={}, "
+        "force_lod11_attribute={}, yoc_attribute={}, layer_name={}, "
+        "layer_id={}, attribute_filter={}, ceil_point_density={}, cellsize={}, "
+        "lod11_fallback_area={}, lod11_fallback_density={}, tilesize={}, "
+        "clear_if_insufficient={}, write_crop_outputs={}, output_all={}, "
+        "write_rasters={}, write_index={}, region_of_interest={}, "
+        "srs_override={}, split_cjseq={}, building_toml_file_spec={}, "
+        "building_las_file_spec={}, building_gpkg_file_spec={}, "
+        "building_raster_file_spec={}, building_jsonl_file_spec={}, "
+        "jsonl_list_file_spec={}, index_file_spec={}, "
+        "metadata_json_file_spec={}, output_path={}, rec={})",
+        cfg.source_footprints, cfg.id_attribute, cfg.force_lod11_attribute,
+        cfg.yoc_attribute, cfg.layer_name, cfg.layer_id, cfg.attribute_filter,
+        cfg.ceil_point_density, cfg.cellsize, cfg.lod11_fallback_area,
+        cfg.lod11_fallback_density, cfg.tilesize, cfg.clear_if_insufficient,
+        cfg.write_crop_outputs, cfg.output_all, cfg.write_rasters,
+        cfg.write_index, region_of_interest, cfg.srs_override, cfg.split_cjseq,
+        cfg.building_toml_file_spec, cfg.building_las_file_spec,
+        cfg.building_gpkg_file_spec, cfg.building_raster_file_spec,
+        cfg.building_jsonl_file_spec, cfg.jsonl_list_file_spec,
+        cfg.index_file_spec, cfg.metadata_json_file_spec, cfg.output_path,
+        cfg.rec);
+  }
 };
 
 template <typename T>

--- a/apps/roofer-app/roofer-app.cpp
+++ b/apps/roofer-app/roofer-app.cpp
@@ -795,6 +795,9 @@ int main(int argc, const char* argv[]) {
               "[reconstructor] Submitted all buildings for reconstruction for "
               "tile {}",
               building_tile);
+          // Here the building_tile.buildings is empty, because we moved off all
+          // BuildingObject-s, so we might as well clear it.
+          building_tile.buildings.clear();
           reconstructed_tiles.push_back(std::move(building_tile));
           cropped_tiles.pop_front();
           // This wakes up the serializer thread as soon as we submitted one
@@ -900,15 +903,17 @@ int main(int argc, const char* argv[]) {
           //  loop on each building...
           for (size_t i = 0; i < reconstructed_tiles.size(); i++) {
             auto& building_tile = reconstructed_tiles[i];
-            // We expect that the building_tile.buildings container hasn't been
-            // cleared, so that we can insert the reconstructed building at the
-            // index.
-            assert(building_tile.buildings.size() ==
-                   building_tile.buildings_cnt);
+            // The reconstructor moved off all items from the
+            // building_tile.buildings container, which can mess up its size. We
+            // need to make sure that the container is the right size, so that
+            // we can insert the reconstructed building at the index.
+            if (building_tile.buildings.size() != building_tile.buildings_cnt) {
+              building_tile.buildings.resize(building_tile.buildings_cnt);
+            }
             if (building_tile.id == bref.tile_id) {
-              building_tile.buildings[bref.building_idx] =
+              building_tile.buildings.at(bref.building_idx) =
                   std::move(bref.building);
-              building_tile.buildings_progresses[bref.building_idx] =
+              building_tile.buildings_progresses.at(bref.building_idx) =
                   bref.progress;
             }
 

--- a/apps/roofer-app/roofer-app.cpp
+++ b/apps/roofer-app/roofer-app.cpp
@@ -228,7 +228,7 @@ struct fmt::formatter<BuildingTile> {
         ctx.out(),
         "BuildingTile(id={}, buildings.size={}, attributes.has_attributes={}, "
         "buildings_progresses={}, buildings_cnt={}, "
-        "proj_helper.data_offset.has_value={}, extent='{}'",
+        "proj_helper.data_offset.has_value={}, extent='{}')",
         tile.id, tile.buildings.size(), tile.attributes.has_attributes(),
         progress_counts, tile.buildings_cnt, data_offset_has_value,
         tile.extent.wkt());
@@ -572,6 +572,8 @@ int main(int argc, const char* argv[]) {
       logger.info("Using user override SRS: {}", roofer_cfg.srs_override);
     }
   }
+
+  logger.debug("{}", roofer_cfg);
 
   for (auto& ipc : input_pointclouds) {
     get_las_extents(ipc, project_srs.get());

--- a/apps/roofer-app/roofer-app.cpp
+++ b/apps/roofer-app/roofer-app.cpp
@@ -1105,4 +1105,6 @@ int main(int argc, const char* argv[]) {
         "not empty, it still contains {} items",
         reconstructed_buildings.size());
   }
+
+  logger.info("Finished roofer");
 }

--- a/apps/roofer-app/roofer-app.cpp
+++ b/apps/roofer-app/roofer-app.cpp
@@ -228,11 +228,10 @@ struct fmt::formatter<BuildingTile> {
         ctx.out(),
         "BuildingTile(id={}, buildings.size={}, attributes.has_attributes={}, "
         "buildings_progresses={}, buildings_cnt={}, "
-        "proj_helper.data_offset.has_value={}, extent=({} {}, {} {}))",
+        "proj_helper.data_offset.has_value={}, extent='{}'",
         tile.id, tile.buildings.size(), tile.attributes.has_attributes(),
         progress_counts, tile.buildings_cnt, data_offset_has_value,
-        tile.extent.pmin[0], tile.extent.pmin[1], tile.extent.pmax[0],
-        tile.extent.pmax[1]);
+        tile.extent.wkt());
   }
 };
 

--- a/apps/roofer-app/roofer-app.cpp
+++ b/apps/roofer-app/roofer-app.cpp
@@ -899,26 +899,30 @@ int main(int argc, const char* argv[]) {
           //  reconstructed_tiles remains relatively low. But we need to do the
           //  loop on each building...
           for (size_t i = 0; i < reconstructed_tiles.size(); i++) {
-            auto& tile = reconstructed_tiles[i];
-            // We expect that the tile.buildings container hasn't been cleared,
-            // so that we can insert the reconstructed building at the index.
-            assert(tile.buildings.size() == tile.buildings_cnt);
-            if (tile.id == bref.tile_id) {
-              tile.buildings[bref.building_idx] = std::move(bref.building);
-              tile.buildings_progresses[bref.building_idx] = bref.progress;
+            auto& building_tile = reconstructed_tiles[i];
+            // We expect that the building_tile.buildings container hasn't been
+            // cleared, so that we can insert the reconstructed building at the
+            // index.
+            assert(building_tile.buildings.size() ==
+                   building_tile.buildings_cnt);
+            if (building_tile.id == bref.tile_id) {
+              building_tile.buildings[bref.building_idx] =
+                  std::move(bref.building);
+              building_tile.buildings_progresses[bref.building_idx] =
+                  bref.progress;
             }
 
             auto tile_finished = std::all_of(
-                tile.buildings_progresses.begin(),
-                tile.buildings_progresses.end(),
+                building_tile.buildings_progresses.begin(),
+                building_tile.buildings_progresses.end(),
                 [](Progress p) { return p > RECONSTRUCTION_IN_PROGRESS; });
             if (tile_finished) {
               finished_idx.first = true;
               finished_idx.second = i;
-              logger.debug("[sorter] tile_finished=true: {}", tile);
+              logger.debug("[sorter] tile_finished=true: {}", building_tile);
               {
                 std::scoped_lock lock_sorted{sorted_tiles_mutex};
-                sorted_tiles.push_back(std::move(tile));
+                sorted_tiles.push_back(std::move(building_tile));
               }
               sorted_pending.notify_one();
             }

--- a/include/roofer/common/box.hpp
+++ b/include/roofer/common/box.hpp
@@ -21,6 +21,9 @@
 
 #include <array>
 #include <initializer_list>
+#include <string>
+#include <sstream>
+#include <iomanip>
 
 namespace roofer {
 
@@ -102,6 +105,19 @@ namespace roofer {
       return {(pmax[0] + pmin[0]) / 2, (pmax[1] + pmin[1]) / 2,
               (pmax[2] + pmin[2]) / 2};
     };
+    std::string wkt() const {
+      if (isEmpty()) return "POLYGON EMPTY";
+      std::ostringstream oss;
+      oss << std::fixed << std::setprecision(2);
+      oss << "POLYGON((";
+      oss << pmin[0] << " " << pmin[1] << ", ";
+      oss << pmax[0] << " " << pmin[1] << ", ";
+      oss << pmax[0] << " " << pmax[1] << ", ";
+      oss << pmin[0] << " " << pmax[1] << ", ";
+      oss << pmin[0] << " " << pmin[1];
+      oss << "))";
+      return oss.str();
+    }
   };
 
   typedef TBox<float> Box;


### PR DESCRIPTION
- Implement formatter for Progress, BuildingTile, RooferConfig, ReconstructionConfig (closes #73)
- I added the ReconstructionConfig formatter to roofer-app/config.hpp together with the RooferConfig, because I did not want to pollute the ReconstructionConfig.hpp with the fmt dependency. 
- I did not want to move the formatters to the logger library because then the logger would depend on roofer
- Implement wkt for TBox (closes #31)
- Replaced an assertion with a resize, to make sure that the container is the right size

Example log for a RooferConfig:

```
5: [2024-11-21 13:19:14.882427602]	DEBUG	RooferConfig(source_footprints=data/issue-71-v2/issue-71.gpkg, id_attribute=identificatie, force_lod11_attribute=kas_warenhuis, yoc_attribute=, layer_name=, layer_id=0, attribute_filter=, ceil_point_density=20, cellsize=0.5, lod11_fallback_area=69000, lod11_fallback_density=5, tilesize=[1000, 1000], clear_if_insufficient=false, write_crop_outputs=false, output_all=false, write_rasters=false, write_index=false, region_of_interest=novalue, srs_override=, split_cjseq=false, building_toml_file_spec={path}/objects/{bid}/config_{pc_name}.toml, building_las_file_spec={path}/objects/{bid}/crop/{bid}_{pc_name}.las, building_gpkg_file_spec={path}/objects/{bid}/crop/{bid}.gpkg, building_raster_file_spec={path}/objects/{bid}/crop/{bid}_{pc_name}.tif, building_jsonl_file_spec={path}/objects/{bid}/reconstruct/{bid}.city.jsonl, jsonl_list_file_spec={path}/features.txt, index_file_spec={path}/index.gpkg, metadata_json_file_spec={path}/metadata.json, output_path=output/issue-71-v2, rec=ReconstructionConfig(complexity_factor=0.7, clip_ground=true, lod=22, lod13_step_height=3, floor_elevation=0, override_with_floor_elevation=false, plane_detect_k=15, plane_detect_min_points=15, plane_detect_epsilon=0.3, plane_detect_normal_angle=0.75, line_detect_epsilon=1, thres_alpha=0.25, thres_reg_line_dist=0.5, thres_reg_line_ext=1))
```

Example log for a BuildingTile:
```
5: [2024-11-21 12:19:29.433273899]	DEBUG	[reconstructor] Submitted all buildings for reconstruction for tile BuildingTile(id=0, buildings.size=315, attributes.has_attributes=true, buildings_progresses=[(4, 315)], buildings_cnt=315, proj_helper.data_offset.has_value=true, extent='POLYGON((102574.71 454546.80, 103574.71 454546.80, 103574.71 455546.80, 102574.71 455546.80, 102574.71 454546.80))'
```