### PR TITLE
fix ambiguity between libraries fmt and stl with function 'format_to' in roofer_app

### DIFF
--- a/apps/roofer-app/config.hpp
+++ b/apps/roofer-app/config.hpp
@@ -157,7 +157,7 @@ struct fmt::formatter<roofer::ReconstructionConfig> {
   template <typename Context>
   constexpr auto format(roofer::ReconstructionConfig const& cfg,
                         Context& ctx) const {
-    return format_to(
+    return fmt::format_to(
         ctx.out(),
         "ReconstructionConfig(complexity_factor={}, clip_ground={}, lod={}, "
         "lod13_step_height={}, floor_elevation={}, "
@@ -183,7 +183,7 @@ struct fmt::formatter<RooferConfig> {
     if (cfg.region_of_interest.has_value()) {
       region_of_interest = cfg.region_of_interest.value().wkt();
     }
-    return format_to(
+    return fmt::format_to(
         ctx.out(),
         "RooferConfig(source_footprints={}, id_attribute={}, "
         "force_lod11_attribute={}, yoc_attribute={}, layer_name={}, "

--- a/apps/roofer-app/roofer-app.cpp
+++ b/apps/roofer-app/roofer-app.cpp
@@ -229,7 +229,7 @@ struct fmt::formatter<BuildingTile> {
     if (tile.proj_helper) {
       data_offset_has_value = tile.proj_helper->data_offset.has_value();
     }
-    return format_to(
+    return fmt::format_to(
         ctx.out(),
         "BuildingTile(id={}, buildings.size={}, attributes.has_attributes={}, "
         "buildings_progresses={}, buildings_cnt={}, "


### PR DESCRIPTION
in environement ubuntu, with c++20, both STL and FMT (v9+) libraries have a fucntion format_to that matches the signature of the call in roofer-app/roofer-app.cpp and roofer-app/config.hpp so we have to precise the namespace before the call
(fmt::format_to)