### PR TITLE
use config variable instead of lib name in CMakeLists

### DIFF
--- a/src/extra/io/CMakeLists.txt
+++ b/src/extra/io/CMakeLists.txt
@@ -26,4 +26,4 @@ find_package(GDAL CONFIG REQUIRED)
 
 add_library("io" OBJECT ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
 target_include_directories("io" PUBLIC ${LIBRARY_INCLUDES})
-target_link_libraries("io" PUBLIC GDAL::GDAL LASlib nlohmann_json::nlohmann_json)
+target_link_libraries("io" PUBLIC GDAL::GDAL ${laslib_LIBRARIES} nlohmann_json::nlohmann_json)


### PR DESCRIPTION
in my environment:
- ubuntu through docker
- libLAS installed from [conda install ](conda-forge::lastools=20171231)

the name of the library is not correct in src/extra/io/CMakeLists.txt

target_link_libraries("io" PUBLIC GDAL::GDAL **LASlib** nlohmann_json::nlohmann_json)

I suggest to use target_link_libraries("io" PUBLIC GDAL::GDAL ${laslib_LIBRARIES} nlohmann_json::nlohmann_json)

that should work provided the cmake config is correct