### PR TITLE
Improve LoD11 fallback/skip mechanism + timeout

### DIFF
--- a/apps/roofer-app/config.hpp
+++ b/apps/roofer-app/config.hpp
@@ -58,6 +58,7 @@ struct InputPointcloud {
   roofer::vec1f pt_densities;
   roofer::vec1b is_glass_roof;
   roofer::vec1b lod11_forced;
+  roofer::vec1b pointcloud_insufficient;
   std::vector<roofer::LinearRing> nodata_circles;
   std::vector<roofer::PointCollection> building_clouds;
   std::vector<roofer::ImageMap> building_rasters;
@@ -122,7 +123,7 @@ struct RooferConfig {
 
   // output attribute names
   std::unordered_map<std::string, std::string> n = {
-      {"status", "rf_status"},
+      {"success", "rf_success"},
       {"reconstruction_time", "rf_reconstruction_time"},
       {"val3dity_lod12", "rf_val3dity_lod12"},
       {"val3dity_lod13", "rf_val3dity_lod13"},
@@ -152,6 +153,7 @@ struct RooferConfig {
       {"slope", "rf_slope"},
       {"azimuth", "rf_azimuth"},
       {"extrusion_mode", "rf_extrusion_mode"},
+      {"pointcloud_insufficient", "rf_pointcloud_insufficient"},
   };
 };
 

--- a/apps/roofer-app/config.hpp
+++ b/apps/roofer-app/config.hpp
@@ -117,14 +117,14 @@ struct RooferConfig {
   std::string output_path;
 
   // reconstruct
-  int lod11_fallback_planes = 100;
-  int lod11_fallback_time = 90000;
+  int lod11_fallback_planes = 900;
+  int lod11_fallback_time = 1800000;
   roofer::ReconstructionConfig rec;
 
   // output attribute names
   std::unordered_map<std::string, std::string> n = {
       {"success", "rf_success"},
-      {"reconstruction_time", "rf_reconstruction_time"},
+      {"reconstruction_time", "rf_t_run"},
       {"val3dity_lod12", "rf_val3dity_lod12"},
       {"val3dity_lod13", "rf_val3dity_lod13"},
       {"val3dity_lod22", "rf_val3dity_lod22"},
@@ -142,7 +142,7 @@ struct RooferConfig {
       {"h_roof_70p", "rf_h_roof_70p"},
       {"h_roof_min", "rf_h_roof_min"},
       {"h_roof_max", "rf_h_roof_max"},
-      {"roof_n_planes", "rf_roof_n_planes"},
+      {"roof_n_planes", "rf_roof_planes"},
       {"rmse_lod12", "rf_rmse_lod12"},
       {"rmse_lod13", "rf_rmse_lod13"},
       {"rmse_lod22", "rf_rmse_lod22"},
@@ -153,7 +153,7 @@ struct RooferConfig {
       {"slope", "rf_slope"},
       {"azimuth", "rf_azimuth"},
       {"extrusion_mode", "rf_extrusion_mode"},
-      {"pointcloud_insufficient", "rf_pointcloud_insufficient"},
+      {"pointcloud_unusable", "rf_pointcloud_unusable"},
   };
 };
 

--- a/apps/roofer-app/config.hpp
+++ b/apps/roofer-app/config.hpp
@@ -85,7 +85,7 @@ struct RooferConfig {
   int lod11_fallback_area = 69000;
   float lod11_fallback_density = 5;
   roofer::arr2f tilesize = {1000, 1000};
-  bool clear_if_insufficient = false;
+  bool clear_if_insufficient = true;
 
   bool write_crop_outputs = false;
   bool output_all = false;
@@ -151,6 +151,7 @@ struct RooferConfig {
       {"h_ground", "rf_h_ground"},
       {"slope", "rf_slope"},
       {"azimuth", "rf_azimuth"},
+      {"extrusion_mode", "rf_extrusion_mode"},
   };
 };
 
@@ -645,7 +646,8 @@ struct RooferConfigHandler {
         _cfg.cellsize, {roofer::v::HigherThan<float>(0)});
     add("lod11-fallback-area", "lod11 fallback area", _cfg.lod11_fallback_area,
         {roofer::v::HigherThan<int>(0)});
-    add("skip-insufficient", "skip buildings with insufficient pointcloud data",
+    add("reconstruct-insufficient",
+        "reconstruct buildings with insufficient pointcloud data",
         _cfg.clear_if_insufficient, {});
     // add("lod11-fallback-density", "lod11 fallback density",
     // _cfg.lod11_fallback_density, {roofer::v::HigherThan<float>(0)}});

--- a/apps/roofer-app/config.hpp
+++ b/apps/roofer-app/config.hpp
@@ -115,6 +115,9 @@ struct RooferConfig {
   std::string output_path;
 
   // reconstruct
+  bool limit_planedetector = false;
+  int limit_n_regions = 100;
+  int limit_n_milliseconds = 10000;
   roofer::ReconstructionConfig rec;
 
   // output attribute names
@@ -682,6 +685,13 @@ struct RooferConfigHandler {
         _cfg.cj_scale, {});
     add("cj-translate", "Translation applied to CityJSON output vertices",
         _cfg.cj_translate, {});
+    add("limit-planedetector",
+        "Limit the number of regions and time spent in the plane detector",
+        _cfg.limit_planedetector, {});
+    add("limit-n-regions", "Limit the number of regions", _cfg.limit_n_regions,
+        {roofer::v::HigherThan<int>(0)});
+    add("limit-n-milliseconds", "Limit the time spent in the plane detector",
+        _cfg.limit_n_milliseconds, {roofer::v::HigherThan<int>(0)});
     addr("plane-detect-k", "plane detect k", _cfg.rec.plane_detect_k,
          {roofer::v::HigherThan<int>(0)});
     addr("plane-detect-min-points", "plane detect min points",

--- a/apps/roofer-app/config.hpp
+++ b/apps/roofer-app/config.hpp
@@ -116,9 +116,8 @@ struct RooferConfig {
   std::string output_path;
 
   // reconstruct
-  bool limit_planedetector = false;
-  int limit_n_regions = 100;
-  int limit_n_milliseconds = 10000;
+  int lod11_fallback_planes = 100;
+  int lod11_fallback_time = 90000;
   roofer::ReconstructionConfig rec;
 
   // output attribute names
@@ -686,13 +685,13 @@ struct RooferConfigHandler {
         _cfg.cj_scale, {});
     add("cj-translate", "Translation applied to CityJSON output vertices",
         _cfg.cj_translate, {});
-    add("limit-planedetector",
-        "Limit the number of regions and time spent in the plane detector",
-        _cfg.limit_planedetector, {});
-    add("limit-n-regions", "Limit the number of regions", _cfg.limit_n_regions,
-        {roofer::v::HigherThan<int>(0)});
-    add("limit-n-milliseconds", "Limit the time spent in the plane detector",
-        _cfg.limit_n_milliseconds, {roofer::v::HigherThan<int>(0)});
+    add("lod11-fallback-planes",
+        "Fallback to LoD11 if number of detected planes exceeds this value.",
+        _cfg.lod11_fallback_planes, {roofer::v::HigherThan<int>(0)});
+    add("lod11-fallback-time",
+        "Fallback to LoD11 if time spent on detecting planes exceeds this "
+        "value. In milliseconds.",
+        _cfg.lod11_fallback_time, {roofer::v::HigherThan<int>(0)});
     addr("plane-detect-k", "plane detect k", _cfg.rec.plane_detect_k,
          {roofer::v::HigherThan<int>(0)});
     addr("plane-detect-min-points", "plane detect min points",

--- a/apps/roofer-app/config.hpp
+++ b/apps/roofer-app/config.hpp
@@ -689,7 +689,7 @@ struct RooferConfigHandler {
         _cfg.cj_scale, {});
     add("cj-translate", "Translation applied to CityJSON output vertices",
         _cfg.cj_translate, {});
-    add("lod11-fallback-planes",
+    add("lod11-fallback-plane-cnt",
         "Fallback to LoD11 if number of detected planes exceeds this value.",
         _cfg.lod11_fallback_planes, {roofer::v::HigherThan<int>(0)});
     add("lod11-fallback-time",

--- a/apps/roofer-app/config.hpp
+++ b/apps/roofer-app/config.hpp
@@ -62,6 +62,7 @@ struct InputPointcloud {
   std::vector<roofer::PointCollection> building_clouds;
   std::vector<roofer::ImageMap> building_rasters;
   roofer::vec1f ground_elevations;
+  roofer::vec1f roof_elevations;
   roofer::vec1i acquisition_years;
 
   std::unique_ptr<roofer::misc::RTreeInterface> rtree;

--- a/apps/roofer-app/crop_tile.hpp
+++ b/apps/roofer-app/crop_tile.hpp
@@ -352,14 +352,16 @@ bool crop_tile(const roofer::TBox<double>& tile,
       building.h_roof = input_pointclouds[selected->index].roof_elevations[i];
       building.force_lod11 = input_pointclouds[selected->index].lod11_forced[i];
 
+      if (input_pointclouds[selected->index].lod11_forced[i]) {
+        building.extrusion_mode = ExtrusionMode::LOD11_FALLBACK;
+        force_lod11_vec[i] = input_pointclouds[selected->index].lod11_forced[i];
+      }
+
       output_building_tile.attributes = attributes;
       building.jsonl_path = fmt::format(
           fmt::runtime(cfg.building_jsonl_file_spec), fmt::arg("bid", bid),
           fmt::arg("pc_name", input_pointclouds[selected->index].name),
           fmt::arg("path", cfg.output_path));
-    }
-    if (input_pointclouds[selected->index].lod11_forced[i]) {
-      force_lod11_vec[i] = input_pointclouds[selected->index].lod11_forced[i];
     }
 
     if (cfg.write_crop_outputs) {

--- a/apps/roofer-app/crop_tile.hpp
+++ b/apps/roofer-app/crop_tile.hpp
@@ -94,7 +94,8 @@ bool crop_tile(const roofer::TBox<double>& tile,
 
     PointCloudCropper->process(
         lasfiles, footprints, buffered_footprints, ipc.building_clouds,
-        ipc.ground_elevations, ipc.acquisition_years, polygon_extent,
+        ipc.ground_elevations, ipc.acquisition_years,
+        ipc.pointcloud_insufficient, polygon_extent,
         {.ground_class = ipc.grnd_class,
          .building_class = ipc.bld_class,
          .clear_if_insufficient = cfg.clear_if_insufficient,
@@ -132,6 +133,7 @@ bool crop_tile(const roofer::TBox<double>& tile,
     ipc.is_glass_roof.reserve(N_fp);
     ipc.roof_elevations.reserve(N_fp);
     ipc.lod11_forced.reserve(N_fp);
+    ipc.pointcloud_insufficient.reserve(N_fp);
     if (cfg.write_index) ipc.nodata_circles.resize(N_fp);
 
     // auto& r_nodata = attributes.insert_vec<float>("r_nodata_"+ipc.name);
@@ -349,8 +351,11 @@ bool crop_tile(const roofer::TBox<double>& tile,
       building.footprint = footprints[i];
       building.h_ground =
           input_pointclouds[selected->index].ground_elevations[i];
-      building.h_roof = input_pointclouds[selected->index].roof_elevations[i];
+      building.h_roof_70p_rough =
+          input_pointclouds[selected->index].roof_elevations[i];
       building.force_lod11 = input_pointclouds[selected->index].lod11_forced[i];
+      building.pointcloud_insufficient =
+          input_pointclouds[selected->index].pointcloud_insufficient[i];
 
       if (input_pointclouds[selected->index].lod11_forced[i]) {
         building.extrusion_mode = ExtrusionMode::LOD11_FALLBACK;

--- a/apps/roofer-app/crop_tile.hpp
+++ b/apps/roofer-app/crop_tile.hpp
@@ -130,6 +130,7 @@ bool crop_tile(const roofer::TBox<double>& tile,
     ipc.nodata_fractions.resize(N_fp);
     ipc.pt_densities.resize(N_fp);
     ipc.is_glass_roof.reserve(N_fp);
+    ipc.roof_elevations.reserve(N_fp);
     ipc.lod11_forced.reserve(N_fp);
     if (cfg.write_index) ipc.nodata_circles.resize(N_fp);
 
@@ -145,6 +146,8 @@ bool crop_tile(const roofer::TBox<double>& tile,
           roofer::misc::computePointDensity(ipc.building_rasters[i]);
       ipc.is_glass_roof[i] =
           roofer::misc::testForGlassRoof(ipc.building_rasters[i]);
+      ipc.roof_elevations[i] =
+          roofer::misc::computeRoofElevation(ipc.building_rasters[i], 0.7);
 
       auto target_density = cfg.ceil_point_density;
       bool do_force_lod11 =
@@ -346,6 +349,7 @@ bool crop_tile(const roofer::TBox<double>& tile,
       building.footprint = footprints[i];
       building.h_ground =
           input_pointclouds[selected->index].ground_elevations[i];
+      building.h_roof = input_pointclouds[selected->index].roof_elevations[i];
       building.force_lod11 = input_pointclouds[selected->index].lod11_forced[i];
 
       output_building_tile.attributes = attributes;

--- a/apps/roofer-app/crop_tile.hpp
+++ b/apps/roofer-app/crop_tile.hpp
@@ -192,27 +192,19 @@ bool crop_tile(const roofer::TBox<double>& tile,
 
   // add raster stats attributes from PointCloudCropper to footprint attributes
   for (auto& ipc : input_pointclouds) {
-    auto& h_ground =
-        attributes.insert_vec<float>(cfg.n.at("h_ground") + "_" + ipc.name);
     auto& nodata_r =
         attributes.insert_vec<float>(cfg.n.at("nodata_r") + "_" + ipc.name);
     auto& nodata_frac =
         attributes.insert_vec<float>(cfg.n.at("nodata_frac") + "_" + ipc.name);
     auto& pt_density =
         attributes.insert_vec<float>(cfg.n.at("pt_density") + "_" + ipc.name);
-    auto& is_glass_roof =
-        attributes.insert_vec<bool>(cfg.n.at("is_glass_roof") + "_" + ipc.name);
-    h_ground.reserve(N_fp);
     nodata_r.reserve(N_fp);
     nodata_frac.reserve(N_fp);
     pt_density.reserve(N_fp);
-    is_glass_roof.reserve(N_fp);
     for (unsigned i = 0; i < N_fp; ++i) {
-      h_ground.push_back(ipc.ground_elevations[i] + (*pj->data_offset)[2]);
       nodata_r.push_back(ipc.nodata_radii[i]);
       nodata_frac.push_back(ipc.nodata_fractions[i]);
       pt_density.push_back(ipc.pt_densities[i]);
-      is_glass_roof.push_back(ipc.is_glass_roof[i]);
     }
   }
 
@@ -356,6 +348,8 @@ bool crop_tile(const roofer::TBox<double>& tile,
       building.force_lod11 = input_pointclouds[selected->index].lod11_forced[i];
       building.pointcloud_insufficient =
           input_pointclouds[selected->index].pointcloud_insufficient[i];
+      building.is_glass_roof =
+          input_pointclouds[selected->index].is_glass_roof[i];
 
       if (input_pointclouds[selected->index].lod11_forced[i]) {
         building.extrusion_mode = ExtrusionMode::LOD11_FALLBACK;

--- a/apps/roofer-app/reconstruct_building.hpp
+++ b/apps/roofer-app/reconstruct_building.hpp
@@ -174,6 +174,9 @@ void reconstruct_building(BuildingObject& building, RooferConfig* rfcfg) {
           .metrics_plane_min_points = cfg->plane_detect_min_points,
           .metrics_plane_epsilon = cfg->plane_detect_epsilon,
           .metrics_plane_normal_threshold = cfg->plane_detect_normal_angle,
+          .with_limits = rfcfg->limit_planedetector,
+          .limit_n_regions = rfcfg->limit_n_regions,
+          .limit_n_milliseconds = rfcfg->limit_n_milliseconds,
       });
   timings["PlaneDetector"] = std::chrono::high_resolution_clock::now() - t0;
   // logger.debug("Completed PlaneDetector (roof), found {} roofplanes",
@@ -198,7 +201,17 @@ void reconstruct_building(BuildingObject& building, RooferConfig* rfcfg) {
 
   t0 = std::chrono::high_resolution_clock::now();
   auto PlaneDetector_ground = roofer::reconstruction::createPlaneDetector();
-  PlaneDetector_ground->detect(building.pointcloud_ground);
+  PlaneDetector_ground->detect(
+      building.pointcloud_ground,
+      {
+          .metrics_plane_k = cfg->plane_detect_k,
+          .metrics_plane_min_points = cfg->plane_detect_min_points,
+          .metrics_plane_epsilon = cfg->plane_detect_epsilon,
+          .metrics_plane_normal_threshold = cfg->plane_detect_normal_angle,
+          .with_limits = rfcfg->limit_planedetector,
+          .limit_n_regions = rfcfg->limit_n_regions,
+          .limit_n_milliseconds = rfcfg->limit_n_milliseconds,
+      });
   timings["PlaneDetector_ground"] =
       std::chrono::high_resolution_clock::now() - t0;
   // logger.debug("Completed PlaneDetector (ground), found {} groundplanes",

--- a/apps/roofer-app/reconstruct_building.hpp
+++ b/apps/roofer-app/reconstruct_building.hpp
@@ -237,9 +237,10 @@ void reconstruct_building(BuildingObject& building, RooferConfig* rfcfg) {
         building.extrusion_mode = SKIP;
         return;
       }
-    } catch (const std::exception& e) {
+    } catch (const std::runtime_error& e) {
       extrude_lod11(building, rfcfg);
-      // logger.info("Falling back to LoD1.1: {}", e.what());
+      logger.warning("[reconstructor] {}, LoD1.1 fallback: {}",
+                     building.jsonl_path.string(), e.what());
       return;
     }
     // #ifdef RF_USE_RERUN

--- a/apps/roofer-app/reconstruct_building.hpp
+++ b/apps/roofer-app/reconstruct_building.hpp
@@ -165,67 +165,6 @@ void reconstruct_building(BuildingObject& building, RooferConfig* rfcfg) {
 
   std::unordered_map<std::string, std::chrono::duration<double>> timings;
 
-  auto t0 = std::chrono::high_resolution_clock::now();
-  auto PlaneDetector = roofer::reconstruction::createPlaneDetector();
-  PlaneDetector->detect(
-      building.pointcloud_building,
-      {
-          .metrics_plane_k = cfg->plane_detect_k,
-          .metrics_plane_min_points = cfg->plane_detect_min_points,
-          .metrics_plane_epsilon = cfg->plane_detect_epsilon,
-          .metrics_plane_normal_threshold = cfg->plane_detect_normal_angle,
-          .with_limits = rfcfg->limit_planedetector,
-          .limit_n_regions = rfcfg->limit_n_regions,
-          .limit_n_milliseconds = rfcfg->limit_n_milliseconds,
-      });
-  timings["PlaneDetector"] = std::chrono::high_resolution_clock::now() - t0;
-  // logger.debug("Completed PlaneDetector (roof), found {} roofplanes",
-  //  PlaneDetector->pts_per_roofplane.size());
-
-  building.roof_type = PlaneDetector->roof_type;
-  building.roof_elevation_50p = PlaneDetector->roof_elevation_50p;
-  building.roof_elevation_70p = PlaneDetector->roof_elevation_70p;
-  building.roof_elevation_min = PlaneDetector->roof_elevation_min;
-  building.roof_elevation_max = PlaneDetector->roof_elevation_max;
-  building.roof_n_planes = PlaneDetector->pts_per_roofplane.size();
-
-  bool pointcloud_insufficient = PlaneDetector->roof_type == "no points" ||
-                                 PlaneDetector->roof_type == "no planes";
-  if (pointcloud_insufficient) {
-    // building.was_skipped = true;
-    // TODO: return building status pointcloud_insufficient
-    // CityJsonWriter->write(path_output_jsonl, footprints, nullptr, nullptr,
-    //                       nullptr, attributes);
-    return;
-  }
-
-  t0 = std::chrono::high_resolution_clock::now();
-  auto PlaneDetector_ground = roofer::reconstruction::createPlaneDetector();
-  PlaneDetector_ground->detect(
-      building.pointcloud_ground,
-      {
-          .metrics_plane_k = cfg->plane_detect_k,
-          .metrics_plane_min_points = cfg->plane_detect_min_points,
-          .metrics_plane_epsilon = cfg->plane_detect_epsilon,
-          .metrics_plane_normal_threshold = cfg->plane_detect_normal_angle,
-          .with_limits = rfcfg->limit_planedetector,
-          .limit_n_regions = rfcfg->limit_n_regions,
-          .limit_n_milliseconds = rfcfg->limit_n_milliseconds,
-      });
-  timings["PlaneDetector_ground"] =
-      std::chrono::high_resolution_clock::now() - t0;
-  // logger.debug("Completed PlaneDetector (ground), found {} groundplanes",
-  //  PlaneDetector_ground->pts_per_roofplane.size());
-
-#ifdef RF_USE_RERUN
-  rec.log("world/segmented_points",
-          rerun::Collection{rerun::components::AnnotationContext{
-              rerun::datatypes::AnnotationInfo(
-                  0, "no plane", rerun::datatypes::Rgba32(30, 30, 30))}});
-  rec.log("world/segmented_points",
-          rerun::Points3D(points_roof).with_class_ids(PlaneDetector->plane_id));
-#endif
-
   // check skip_attribute
   // logger.debug("force LoD1.1 = {}", building.force_lod11);
 
@@ -233,18 +172,75 @@ void reconstruct_building(BuildingObject& building, RooferConfig* rfcfg) {
     auto SimplePolygonExtruder =
         roofer::reconstruction::createSimplePolygonExtruder();
     SimplePolygonExtruder->compute(building.footprint, building.h_ground,
-                                   PlaneDetector->roof_elevation_70p);
+                                   building.h_roof);
     std::vector<std::unordered_map<int, roofer::Mesh>> multisolidvec;
     building.multisolids_lod12 = SimplePolygonExtruder->multisolid;
     building.multisolids_lod13 = SimplePolygonExtruder->multisolid;
     building.multisolids_lod22 = SimplePolygonExtruder->multisolid;
-    // TODO: return building status
+    // TODO: return rmse, volume, val3dity
     return;
-    // multisolidvec.push_back(SimplePolygonExtruder->multisolid);
-    // CityJsonWriter->write(path_output_jsonl, footprints, &multisolidvec,
-    //                       &multisolidvec, &multisolidvec, attributes);
-    // logger.debug("Completed CityJsonWriter to {}", path_output_jsonl);
   } else {
+    auto t0 = std::chrono::high_resolution_clock::now();
+    auto PlaneDetector = roofer::reconstruction::createPlaneDetector();
+    PlaneDetector->detect(
+        points_roof,
+        {
+            .metrics_plane_k = cfg->plane_detect_k,
+            .metrics_plane_min_points = cfg->plane_detect_min_points,
+            .metrics_plane_epsilon = cfg->plane_detect_epsilon,
+            .metrics_plane_normal_threshold = cfg->plane_detect_normal_angle,
+            .with_limits = rfcfg->limit_planedetector,
+            .limit_n_regions = rfcfg->limit_n_regions,
+            .limit_n_milliseconds = rfcfg->limit_n_milliseconds,
+        });
+    timings["PlaneDetector"] = std::chrono::high_resolution_clock::now() - t0;
+    // logger.debug("Completed PlaneDetector (roof), found {} roofplanes",
+    //  PlaneDetector->pts_per_roofplane.size());
+
+    building.roof_type = PlaneDetector->roof_type;
+    building.roof_elevation_50p = PlaneDetector->roof_elevation_50p;
+    building.roof_elevation_70p = PlaneDetector->roof_elevation_70p;
+    building.roof_elevation_min = PlaneDetector->roof_elevation_min;
+    building.roof_elevation_max = PlaneDetector->roof_elevation_max;
+    building.roof_n_planes = PlaneDetector->pts_per_roofplane.size();
+
+    bool pointcloud_insufficient = PlaneDetector->roof_type == "no points" ||
+                                   PlaneDetector->roof_type == "no planes";
+    if (pointcloud_insufficient) {
+      // building.was_skipped = true;
+      // TODO: return building status pointcloud_insufficient
+      // CityJsonWriter->write(path_output_jsonl, footprints, nullptr, nullptr,
+      //                       nullptr, attributes);
+      return;
+    }
+
+    t0 = std::chrono::high_resolution_clock::now();
+    auto PlaneDetector_ground = roofer::reconstruction::createPlaneDetector();
+    PlaneDetector_ground->detect(
+        points_ground,
+        {
+            .metrics_plane_k = cfg->plane_detect_k,
+            .metrics_plane_min_points = cfg->plane_detect_min_points,
+            .metrics_plane_epsilon = cfg->plane_detect_epsilon,
+            .metrics_plane_normal_threshold = cfg->plane_detect_normal_angle,
+            .with_limits = rfcfg->limit_planedetector,
+            .limit_n_regions = rfcfg->limit_n_regions,
+            .limit_n_milliseconds = rfcfg->limit_n_milliseconds,
+        });
+    timings["PlaneDetector_ground"] =
+        std::chrono::high_resolution_clock::now() - t0;
+    // logger.debug("Completed PlaneDetector (ground), found {} groundplanes",
+    //  PlaneDetector_ground->pts_per_roofplane.size());
+
+#ifdef RF_USE_RERUN
+    rec.log("world/segmented_points",
+            rerun::Collection{rerun::components::AnnotationContext{
+                rerun::datatypes::AnnotationInfo(
+                    0, "no plane", rerun::datatypes::Rgba32(30, 30, 30))}});
+    rec.log(
+        "world/segmented_points",
+        rerun::Points3D(points_roof).with_class_ids(PlaneDetector->plane_id));
+#endif
     t0 = std::chrono::high_resolution_clock::now();
     auto AlphaShaper = roofer::reconstruction::createAlphaShaper();
     AlphaShaper->compute(PlaneDetector->pts_per_roofplane,

--- a/apps/roofer-app/roofer-app.cpp
+++ b/apps/roofer-app/roofer-app.cpp
@@ -108,6 +108,7 @@ struct BuildingObject {
   // set in crop
   fs::path jsonl_path;
   float h_ground;
+  float h_roof;
   bool force_lod11;  // force_lod11 / fallback_lod11
 
   // set in reconstruction

--- a/apps/roofer-app/roofer-app.cpp
+++ b/apps/roofer-app/roofer-app.cpp
@@ -113,6 +113,7 @@ struct BuildingObject {
   float h_roof_70p_rough;
   bool force_lod11;  // force_lod11 / fallback_lod11
   bool pointcloud_insufficient;
+  bool is_glass_roof;
   ExtrusionMode extrusion_mode = STANDARD;
 
   // set in reconstruction
@@ -1070,6 +1071,8 @@ int main(int argc, const char* argv[]) {
                                                     building.attribute_index);
 
               attrow.insert(roofer_cfg.n["h_ground"], building.h_ground);
+              attrow.insert(roofer_cfg.n["is_glass_roof"],
+                            building.is_glass_roof);
               attrow.insert(roofer_cfg.n["pointcloud_unusable"],
                             building.pointcloud_insufficient);
               attrow.insert(roofer_cfg.n["roof_type"], building.roof_type);

--- a/apps/roofer-app/roofer-app.cpp
+++ b/apps/roofer-app/roofer-app.cpp
@@ -85,6 +85,8 @@ namespace fs = std::filesystem;
 
 #include "config.hpp"
 
+enum ExtrusionMode { STANDARD, LOD11_FALLBACK, SKIP };
+
 /**
  * @brief A single building object
  *
@@ -110,6 +112,7 @@ struct BuildingObject {
   float h_ground;
   float h_roof;
   bool force_lod11;  // force_lod11 / fallback_lod11
+  ExtrusionMode extrusion_mode = STANDARD;
 
   // set in reconstruction
   std::string roof_type;
@@ -1078,6 +1081,8 @@ int main(int argc, const char* argv[]) {
                             building.roof_elevation_max);
               attrow.insert(roofer_cfg.n["roof_n_planes"],
                             building.roof_n_planes);
+              attrow.insert(roofer_cfg.n["extrusion_mode"],
+                            building.extrusion_mode);
 
               std::unordered_map<int, roofer::Mesh>* ms12 = nullptr;
               std::unordered_map<int, roofer::Mesh>* ms13 = nullptr;

--- a/include/roofer/common/common.hpp
+++ b/include/roofer/common/common.hpp
@@ -139,6 +139,13 @@ namespace roofer {
     void insert(const std::string& name, T value) {
       _attributes[name] = value;
     };
+    template <typename T>
+    void insert_optional(const std::string& name, std::optional<T> opt) {
+      if (opt.has_value())
+        _attributes[name] = opt.value();
+      else
+        _attributes[name] = std::monostate();
+    };
 
     void set_null(const std::string& name);
     bool is_null(const std::string& name) const;

--- a/include/roofer/io/StreamCropper.hpp
+++ b/include/roofer/io/StreamCropper.hpp
@@ -50,7 +50,8 @@ namespace roofer::io {
         std::vector<LinearRing>& polygons,
         std::vector<LinearRing>& buf_polygons,
         std::vector<PointCollection>& point_clouds, vec1f& ground_elevations,
-        vec1i& acquisition_years, const Box& polygon_extent,
+        vec1i& acquisition_years, vec1b& pointcloud_insufficient,
+        const Box& polygon_extent,
         PointCloudCropperConfig cfg = PointCloudCropperConfig{}) = 0;
     // virtual void process(
     //     std::string filepaths, std::vector<LinearRing>& polygons,

--- a/include/roofer/misc/PointcloudRasteriser.hpp
+++ b/include/roofer/misc/PointcloudRasteriser.hpp
@@ -65,6 +65,8 @@ namespace roofer::misc {
 
   float computePointDensity(const ImageMap& image_bundle);
 
+  float computeRoofElevation(const ImageMap& image_bundle, float percentile);
+
   // Determine if the two point clouds describe the same object.
   bool isMutated(const ImageMap& a, const ImageMap& b,
                  const float& threshold_mutation_fraction,

--- a/include/roofer/reconstruction/PlaneDetector.hpp
+++ b/include/roofer/reconstruction/PlaneDetector.hpp
@@ -49,6 +49,11 @@ namespace roofer::reconstruction {
     bool regularize_orthogonality_ = false;
     bool regularize_coplanarity_ = false;
     bool regularize_axis_symmetry_ = false;
+
+    // limits
+    bool with_limits = false;
+    int limit_n_regions = 100;
+    int limit_n_milliseconds = 10000;
   };
 
   struct PlaneDetectorInterface {

--- a/include/roofer/reconstruction/RegionGrower.hpp
+++ b/include/roofer/reconstruction/RegionGrower.hpp
@@ -137,7 +137,13 @@ namespace roofer {
                 std::chrono::duration_cast<std::chrono::milliseconds>(
                     std::chrono::high_resolution_clock::now() - t_start)
                         .count() >= limit_n_milliseconds) {
-              throw std::runtime_error("Region growing limit reached.");
+              throw std::runtime_error(
+                  "Region growing limit reached. Time = " +
+                  std::to_string(
+                      std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::high_resolution_clock::now() - t_start)
+                          .count()) +
+                  "ms, regioncount = " + std::to_string(regions.size()));
             }
           }
         }

--- a/include/roofer/reconstruction/RegionGrower.hpp
+++ b/include/roofer/reconstruction/RegionGrower.hpp
@@ -24,6 +24,7 @@
 #include <deque>
 #include <type_traits>
 #include <unordered_map>
+#include <chrono>
 
 namespace roofer {
 
@@ -110,6 +111,34 @@ namespace roofer {
           if (region_ids[idx] == 0) {
             grow_one_region(cds, tester, idx);
             ++cur_region_id;
+          }
+        }
+      };
+      template <typename Tester>
+      void grow_regions_with_limits(candidateDS& cds, Tester& tester,
+                                    size_t limit_n_regions,
+                                    size_t limit_n_milliseconds) {
+        std::vector<size_t> new_regions;
+        std::deque<size_t> seeds = cds.get_seeds();
+
+        region_ids.resize(cds.size, 0);
+        // first region means unsegmented
+        regions.push_back(regionType(0));
+
+        // region growing from seed points
+        auto t_start = std::chrono::high_resolution_clock::now();
+        while (seeds.size() > 0) {
+          auto idx = seeds.front();
+          seeds.erase(seeds.begin());
+          if (region_ids[idx] == 0) {
+            grow_one_region(cds, tester, idx);
+            ++cur_region_id;
+            if (regions.size() >= limit_n_regions ||
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::high_resolution_clock::now() - t_start)
+                        .count() >= limit_n_milliseconds) {
+              throw std::runtime_error("Region growing limit reached.");
+            }
           }
         }
       };

--- a/src/core/reconstruction/PlaneDetector.cpp
+++ b/src/core/reconstruction/PlaneDetector.cpp
@@ -269,7 +269,12 @@ namespace roofer {
               R;
           R.min_segment_count = cfg.metrics_plane_min_points;
           if (points.size() > cfg.metrics_plane_min_points)
-            R.grow_regions(PDS, DNTester);
+            if (cfg.with_limits) {
+              R.grow_regions_with_limits(PDS, DNTester, cfg.limit_n_regions,
+                                         cfg.limit_n_milliseconds);
+            } else {
+              R.grow_regions(PDS, DNTester);
+            }
 
           total_plane_cnt = R.regions.size();
           // classify horizontal/vertical planes using plane normals

--- a/src/extra/misc/PointcloudRasteriser.cpp
+++ b/src/extra/misc/PointcloudRasteriser.cpp
@@ -223,6 +223,27 @@ namespace roofer::misc {
     }
   }
 
+  float computeRoofElevation(const ImageMap& pc, float percentile) {
+    const auto& fp = pc.at("fp").array;
+    const auto& h_max = pc.at("max").array;
+    const auto& nodata = pc.at("max").nodataval;
+    // auto& cellsize = pc.at("fp").cellsize;
+    std::vector<float> h_max_in_fp;
+    h_max_in_fp.reserve(fp.size());
+    for (size_t i = 0; i < fp.size(); ++i) {
+      if (fp[i] != 0 && h_max[i] != nodata) {
+        h_max_in_fp.push_back(h_max[i]);
+      }
+    }
+    if (h_max_in_fp.size() == 0) {
+      return 0;
+    }
+    // sort the values
+    std::sort(h_max_in_fp.begin(), h_max_in_fp.end());
+    // get the 70th percentile
+    return h_max_in_fp[h_max_in_fp.size() * percentile];
+  }
+
   bool testForGlassRoof(const ImageMap& pc, float threshold_glass_roof) {
     auto& grp = pc.at("grp").array;
     auto& cellsize = pc.at("grp").cellsize;


### PR DESCRIPTION
For the roofer CLI, fixes #74 
- [x] skip plane detection if fallback initiated prior to reconstruct
- [x] implement timeout for plane detector 
- [x] implement detected planes limit for plane detector
- [x] add respective configuration options `lod11-fallback-time` (in ms) and `lod11-fallback-planes`
- [x] add `rf_extrusion_mode` attribute (values can be: standard, fallback, skip)
- [x] rename `rf_status` to `rf_success`
- [x] compute attributes with lod1.1 extrusion
  - [x] volume
  - [x] val3dity
  - [x] rmse
- [x] set some attributes to null when skipping or doing lod11 fallback
  - [x] h_[min/max/90p]
  - [x] n_planes
  - [x] volume
  - [x] val3dity
  - [x] rmse
- [x] set sensible default values for lod11 fallback time and planes